### PR TITLE
added string comparison to consumer m_restart_on_exception if statement 

### DIFF
--- a/lib/jruby-kafka/consumer.rb
+++ b/lib/jruby-kafka/consumer.rb
@@ -34,7 +34,7 @@ class Kafka::Consumer
       rescue Exception => e
         puts("#{self.class.name} caught exception: #{e.class.name}")
         puts(e.message) if e.message != ''
-        if @m_restart_on_exception
+        if @m_restart_on_exception == 'true'
           sleep(@m_sleep_ms)
           retry
         else


### PR DESCRIPTION
The Kafka::Consumer@m_restart_on_exception attribute is passed in as a String while the if @m_restart_on_exception statement is expecting a boolean, either TrueClass or FalseClass.  The Group calling code parses options into Strings, so modified the if statement to check a string value.