### PR TITLE
update to kafka 0.8.2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ tmp
 target
 .jbundler
 Jarfile.lock
+.mvn
+.idea
+.polyglot.Mavenfile
+Gemfile.lock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,37 +1,18 @@
 PATH
   remote: .
   specs:
-    jruby-kafka (1.4.0-java)
+    jruby-kafka (1.4.1-java)
       jar-dependencies (~> 0)
       ruby-maven (~> 3.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    axiom-types (0.1.1)
-      descendants_tracker (~> 0.0.4)
-      ice_nine (~> 0.11.0)
-      thread_safe (~> 0.3, >= 0.3.1)
-    coercible (1.0.0)
-      descendants_tracker (~> 0.0.1)
-    descendants_tracker (0.0.4)
-      thread_safe (~> 0.3, >= 0.3.1)
-    equalizer (0.0.10)
-    ice_nine (0.11.1)
-    jar-dependencies (0.2.0)
-    maven-tools (1.0.8)
-      virtus (~> 1.0)
+    jar-dependencies (0.2.6)
     rake (10.4.2)
-    ruby-maven (3.1.1.0.11)
-      maven-tools (~> 1.0.8)
-      ruby-maven-libs (= 3.1.1)
-    ruby-maven-libs (3.1.1)
-    thread_safe (0.3.5-java)
-    virtus (1.0.5)
-      axiom-types (~> 0.1)
-      coercible (~> 1.0)
-      descendants_tracker (~> 0.0, >= 0.0.3)
-      equalizer (~> 0.0, >= 0.0.9)
+    ruby-maven (3.3.8)
+      ruby-maven-libs (~> 3.3.1)
+    ruby-maven-libs (3.3.3)
 
 PLATFORMS
   java
@@ -39,3 +20,6 @@ PLATFORMS
 DEPENDENCIES
   jruby-kafka!
   rake (~> 10.4)
+
+BUNDLED WITH
+   1.10.6

--- a/jruby-kafka.gemspec
+++ b/jruby-kafka.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |spec|
 
   spec.name          = 'jruby-kafka'
-  spec.version       = '1.4.0'
+  spec.version       = '1.4.1'
   spec.authors       = ['Joseph Lawson']
   spec.email         = ['joe@joekiller.com']
   spec.description   = 'this is primarily to be used as an interface for logstash'
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir[ 'lib/**/*.rb', 'lib/**/*.jar', 'lib/**/*.xml' ]
 
   #Jar dependencies
-  spec.requirements << "jar 'org.apache.kafka:kafka_2.10', '0.8.2.1'"
+  spec.requirements << "jar 'org.apache.kafka:kafka_2.10', '0.8.2.2'"
   spec.requirements << "jar 'org.slf4j:slf4j-log4j12', '1.7.10'"
 
   # Gem dependencies

--- a/lib/jruby-kafka/kafka-producer.rb
+++ b/lib/jruby-kafka/kafka-producer.rb
@@ -60,7 +60,7 @@ class Kafka::KafkaProducer
   end
 
   # throws FailedToSendMessageException or if not connected, StandardError.
-  def send_msg(topic, partition, key, value)
+  def send_msg(topic, partition, key, value, &block)
     if block
       send_cb_method.call(ProducerRecord.new(topic, partition, key, value), RubyCallback.new(block))
     else


### PR DESCRIPTION
Hi,

Could you please consider updating to kafka 0.8.2.2?
This minor release contains a patch on an issue we have faced using logstash 2.1.1 kafka output based on the jruby-kafka 1.4.0:
[KAFKA-2308] - New producer + Snappy face un-compression errors after broker restart: https://issues.apache.org/jira/browse/KAFKA-2308

Nicolas