### PR TITLE
KafkaProducer: Publishing messages with timestamps.

### DIFF
--- a/lib/jruby-kafka/kafka-producer.rb
+++ b/lib/jruby-kafka/kafka-producer.rb
@@ -40,12 +40,24 @@ class Kafka::KafkaProducer <  Java::org.apache.kafka.clients.producer.KafkaProdu
   java_alias :send_method   , :send, [ProducerRecord]
   java_alias :send_cb_method, :send, [ProducerRecord, Callback.java_class]
 
-  # throws FailedToSendMessageException or if not connected, StandardError.
-  def send_msg(topic, partition, key, value, &block)
+  # Send a message to the cluster.
+  #
+  # @param [String]      topic      The topic to send the message to.
+  # @param [Integer,nil] partition  The topic partition to send the message to, or nil to allow
+  #                                 the configured partitioner class to select the partition.
+  # @param [String,nil]  key        The message key, if there is one.  Otherwise, nil.
+  # @param [String]      value      The message value.
+  # @param [Integer,nil] timestamp  The message timestamp in milliseconds. If nil, the 
+  #                                 producer will assign it the current time.
+  #   
+  # @raise [FailedToSendMessageException] if it can't send the message
+  def send_msg(topic, partition, key, value, timestamp=nil, &block)
+    record = ProducerRecord.new(topic, partition, timestamp, key, value)
+
     if block
-      send_cb_method ProducerRecord.new(topic, partition, key, value), RubyCallback.new(block)
+      send_cb_method record, RubyCallback.new(block)
     else
-      send_method ProducerRecord.new(topic, partition, key, value)
+      send_method record
     end
   end
 end

--- a/test/test_kafka-producer.rb
+++ b/test/test_kafka-producer.rb
@@ -19,7 +19,6 @@ class TestKafkaProducer < Test::Unit::TestCase
     assert(future.isDone(), 'expected message to be done')
     assert(future.get().topic(), topic)
     assert_equal(future.get().partition(), 0)
-
   end
 
   def test_02_send_msg_with_cb
@@ -63,4 +62,38 @@ class TestKafkaProducer < Test::Unit::TestCase
     end
     assert(found.include?('test message'), 'expected to find message: test message')
   end
+
+  def test_04_send_message_with_ts
+    topic = 'test_send'
+    future = send_kafka_producer_msg_ts topic, (Time.now.to_i * 1000)
+    assert_not_nil(future)
+    begin
+      timeout(30) do
+        until future.isDone() do
+          next
+        end
+      end
+    end
+    assert(future.isDone(), 'expected message to be done')
+    assert(future.get().topic(), topic)
+    assert_equal(future.get().partition(), 0)
+  end
+
+  def test_05_send_msg_with_ts_and_cb
+    metadata = exception = nil
+    future = send_kafka_producer_msg_ts_cb('test', (Time.now.to_i * 1000)) { |md,e| metadata = md; exception = e }
+    assert_not_nil(future)    
+    begin
+      timeout(30) do
+        while metadata.nil? && exception.nil? do
+          next
+        end
+      end
+    end
+    assert_not_nil(metadata)   
+    assert_instance_of(Java::OrgApacheKafkaClientsProducer::RecordMetadata, metadata)
+    assert_nil(exception)
+    assert(future.isDone(), 'expected message to be done')
+  end
+
 end

--- a/test/test_kafka-producer.rb
+++ b/test/test_kafka-producer.rb
@@ -81,7 +81,7 @@ class TestKafkaProducer < Test::Unit::TestCase
 
   def test_05_send_msg_with_ts_and_cb
     metadata = exception = nil
-    future = send_kafka_producer_msg_ts_cb('test', (Time.now.to_i * 1000)) { |md,e| metadata = md; exception = e }
+    future = send_kafka_producer_msg_ts_cb(Time.now.to_i * 1000) { |md,e| metadata = md; exception = e }
     assert_not_nil(future)    
     begin
       timeout(30) do

--- a/test/util/kafka-producer.rb
+++ b/test/util/kafka-producer.rb
@@ -15,3 +15,13 @@ def send_kafka_producer_msg_cb(&block)
   producer = Kafka::KafkaProducer.new(KAFKA_PRODUCER_OPTIONS)
   producer.send_msg('test',nil, nil, 'test message', &block)
 end
+
+def send_kafka_producer_msg_ts(topic, timestamp)
+  producer = Kafka::KafkaProducer.new(KAFKA_PRODUCER_OPTIONS)
+  producer.send_msg(topic,nil, nil, 'test message', timestamp)
+end
+
+def send_kafka_producer_msg_ts_cb(timestamp, &block)
+  producer = Kafka::KafkaProducer.new(KAFKA_PRODUCER_OPTIONS)
+  producer.send_msg('test',nil, nil, 'test message', timestamp, &block)
+end


### PR DESCRIPTION
Allow passing in a timestamp for messages at publishing time.